### PR TITLE
Only add 'missing' level if hideNA is FALSE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: surveymv
 Type: Package
 Title: Survey Plots
-Version: 0.7.0
+Version: 0.7.1
 Author: Ravi Selker
 Maintainer: Ravi Selker <selker.ravi@gmail.com>
 Description: Generates summary plots for your survey data.

--- a/R/surveyplot.b.R
+++ b/R/surveyplot.b.R
@@ -75,7 +75,7 @@ surveyPlotClass <- if (requireNamespace('jmvcore')) R6::R6Class(
                     df <- self$data %>%
                         dplyr::select(group=!!group, var=!!var) %>%
                         { if (hideNA) tidyr::drop_na(.) else dplyr::mutate_if(., is.factor, addNA) } %>%
-                        dplyr::mutate_if(is.factor, forcats::fct_na_value_to_level, level = "(Missing)") %>%
+                        { if (hideNA) . else  dplyr::mutate_if(., is.factor, forcats::fct_na_value_to_level, level = "(Missing)") } %>%
                         dplyr::mutate_if(is.factor, private$.ellipsifyLevels) %>%
                         dplyr::group_by_all(.drop = FALSE) %>%
                         dplyr::tally(name = "count") %>% 

--- a/jamovi/0000.yaml
+++ b/jamovi/0000.yaml
@@ -1,12 +1,12 @@
 ---
 title: Survey Plots
 name: surveymv
-version: 0.7.0
+version: 0.7.1
 jms: '1.0'
 authors:
   - Ravi Selker
 maintainer: Ravi Selker <selker.ravi@gmail.com>
-date: '2024-08-27'
+date: '2024-10-01'
 type: R
 description: Generates summary plots for your survey data.
 analyses:


### PR DESCRIPTION
The new `forcats::fct_na_value_to_level` funtion should only be applied if the option to hide the missing values is not checked. Otherwise, the nominal plots will always show the missing value label.